### PR TITLE
attempted support for aggregate command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ directory.
 
 Unlike pytest-mongodb, you cannot specify a real MongoDB connection with the pymongo client.
 
+**For local testing make sure to install ``pytest-async-mongodb`` using `pip install .`**
 
 Basic usage
 -----------

--- a/pytest_async_mongodb/plugin.py
+++ b/pytest_async_mongodb/plugin.py
@@ -54,6 +54,16 @@ class AsyncCursor(mongomock.collection.Cursor):
         except StopIteration:
             raise StopAsyncIteration()
 
+class AsyncCommandCursor(mongomock.command_cursor.CommandCursor):
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self)
+        except StopIteration:
+            raise StopAsyncIteration()
+
 
 @wrapp_methods
 class AsyncCollection(mongomock.Collection):
@@ -84,6 +94,11 @@ class AsyncCollection(mongomock.Collection):
     def find(self, *args, **kwargs) -> AsyncCursor:
         cursor = super().find(*args, **kwargs)
         cursor.__class__ = AsyncCursor
+        return cursor
+
+    def aggregate(self, *args, **kwargs) -> AsyncCommandCursor:
+        cursor = super().aggregate(*args, **kwargs)
+        cursor.__class__ = AsyncCommandCursor
         return cursor
 
 

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -4,6 +4,9 @@ import pytest
 
 pytestmark = pytest.mark.asyncio
 
+async def test_players(async_mongodb):
+    manuel = await async_mongodb.players.find_one({'name': 'Manuel'})
+    assert manuel['surname'] == 'Neuer'
 
 async def test_load(async_mongodb):
     collection_names = await async_mongodb.list_collection_names()
@@ -148,6 +151,38 @@ async def test_find_sorted_with_filter(async_mongodb):
     docs = async_mongodb.championships.find(
         filter={"winner": "France"}, sort=[("year", 1)]
     )
+    docs_list = []
+    async for doc in docs:
+        docs_list.append(doc)
+    assert docs_list == [
+        {
+            "_id": ObjectId("55d2db30f4811f83a1f27bea"),
+            "year": 2006,
+            "host": "Germany",
+            "winner": "France",
+        },
+        {
+            "_id": ObjectId("608b0151a20cf0c679939f59"),
+            "year": 2018,
+            "host": "Russia",
+            "winner": "France",
+        },
+    ]
+
+async def test_aggregate_sorted_with_filter(async_mongodb):
+    pipeline = [
+        {
+            "$match": {
+                "winner": "France"
+            }
+        },
+        {
+            "$sort": {
+                "year": 1
+            }
+        }
+    ]
+    docs = async_mongodb.championships.aggregate(pipeline)
     docs_list = []
     async for doc in docs:
         docs_list.append(doc)


### PR DESCRIPTION
This branch includes:
- use of mongomock CommandCursor to allow for testing of `aggregate` function
- update to tests:
  - inclusion of test included in README
  - `test_aggregate_sorted_with_filter`, which is a duplicate of `test_find_sorted_with_filter`, but uses `aggregate` and a pipeline